### PR TITLE
Changes to juju-git-charm

### DIFF
--- a/juju-git-charm
+++ b/juju-git-charm
@@ -63,9 +63,6 @@ if [ "$pluginCommand" == "--install" ]; then # If we are installing a Juju charm
 
 				echo 'ubuntuReleaseName="'$ubuntuReleaseName'"' > ~/juju-git-charms/.$charmName # Add the variable to a "hidden" file
 
-				cd $charmName
-				git remote add upstream $gitRepo # Add the repo as upstream
-
 				mkdir -p ~/charms/$ubuntuReleaseName/ # Recursive make the necessary charms folders if they do not exist
 
 				if [ "$gitFolder" != "" ]; then # If a git folder is specified
@@ -90,7 +87,7 @@ if [ "$pluginCommand" == "--update" ]; then # If we are updating a git repo
 
 		cd $charmName
 		echo "Updating the git repository..."
-		git pull upstream master # Update the contents of the git repo
+		git pull origin master # Update the contents of the git repo
 		
 		echo "Re-installing the charm"
 		if [ "$gitFolder" != "" ]; then # If there IS a gitFolder in the config


### PR DESCRIPTION
Updated juju-git-charm to use git clone rather than make directory, git init, add repo as upstream (rather than origin, which is was before), etc.
