### PR TITLE
Added the juju-pdb plugin for being used with `charmhelpers/contrib/python/debug'

### DIFF
--- a/juju-pdb
+++ b/juju-pdb
@@ -1,0 +1,54 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+# This plugin handles a connection to a remote python
+# debugger already started on a juju unit.
+
+# For more information about the python debugger, please
+# refer to 'charmhelpers/contrib/python/debug'
+
+
+from __future__ import print_function
+
+__author__ = 'Jorge Niedbalski R. <jorge.niedbalski@canonical.com>'
+
+import sys
+import subprocess
+
+from utils import get_units
+from optparse import OptionParser
+
+
+def warning(message):
+    print("WARNING: ", message, file=sys.stderr)
+    sys.exit(-1)
+
+
+def main(options):
+    unit = filter(lambda u: u.name == options.unit, get_units())
+
+    if not len(unit):
+        warning("Not found unit with name: %s" % options.unit)
+
+    unit = unit[0]
+
+    if not "{}/tcp".format(options.port) in unit.open_ports:
+        warning("Port:%s not opened on unit:%s" % (options.port, options.unit))
+
+    subprocess.check_output(["telnet", unit.public_address, options.port])
+
+
+def parse_options():
+    parser = OptionParser()
+    parser.add_option("-u", "--unit", dest="unit",
+                      help="Unit name to debug", metavar="unit")
+
+    parser.add_option("-p", "--port",
+                      dest="port", default="4444",
+                      help="Port on unit where Pdb is binded")
+
+    (options, args) = parser.parse_args()
+    return options
+
+if __name__ == "__main__":
+    main(parse_options())

--- a/juju-pprint
+++ b/juju-pprint
@@ -15,45 +15,9 @@
 # For a full copy of the GNU General Public License, see
 # <http://www.gnu.org/licenses/>.
 
-import os
 import sys
-import yaml
 
-import subprocess
-
-
-class ServiceUnit(object):
-    def __init__(self, name, unit_data):
-        self.name = name
-        self._data = {'public-address': '', 'open-ports': [], 'agent-state': '', 'subordinates': None}
-        self._data.update(unit_data)
-
-    def __getattr__(self, item):
-        return self._data[item.replace('_', '-')]
-
-    def __getitem__(self, item):
-        return self._data[item]
-
-
-def get_juju_status(juju_env=None):
-    cmd = ['juju', 'status']
-    if juju_env:
-        cmd.append(['-e', juju_env])
-    status_raw = subprocess.check_output(cmd)
-    return yaml.safe_load(status_raw)
-
-
-def print_unit(unit, indent=0, quiet=False):
-    status_line = "%s: %s %s (%s)"
-    if not quiet:
-        status_line = "%s- " + status_line
-    else:
-        indent = 0
-        status_line = "%s" + status_line
-
-    print status_line % (" " * indent, unit.name,
-                         unit['public-address'],
-                         ', '.join(unit['open-ports']), unit['agent-state'])
+from utils import get_units, print_unit
 
 
 def main():
@@ -70,17 +34,11 @@ def main():
     if '-q' in sys.argv:
         quiet = True
 
-    status = get_juju_status()
-
-    for service in status['services']:
-        if 'units' in status['services'][service]:
-            for u in status['services'][service]['units']:
-                unit = ServiceUnit(u, status['services'][service]['units'][u])
-                print_unit(unit, quiet=quiet)
-                if unit.subordinates:
-                    for s in unit.subordinates:
-                        sub = ServiceUnit(s, unit.subordinates[s])
-                        print_unit(sub, 2, quiet=quiet)
+    for unit in get_units():
+        if not unit.subordinate:
+            print_unit(unit, quiet=quiet)
+        else:
+            print_unit(unit, 2, quiet=quiet)
 
 
 if __name__ == "__main__":

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import subprocess
+import yaml
+
+
+class ServiceUnit(object):
+    def __init__(self, name, unit_data, subordinate=False):
+        self.name = name
+        self.subordinate = subordinate
+        self._data = {'public-address': '', 'open-ports': [],
+                      'agent-state': '',
+                      'subordinates': None}
+        self._data.update(unit_data)
+
+    def __getattr__(self, item):
+        return self._data[item.replace('_', '-')]
+
+    def __getitem__(self, item):
+        return self._data[item]
+
+
+def get_juju_status(juju_env=None):
+    cmd = ['juju', 'status']
+    if juju_env:
+        cmd.append(['-e', juju_env])
+    status_raw = subprocess.check_output(cmd)
+    return yaml.safe_load(status_raw)
+
+
+def get_units(subordinates=True):
+    status = get_juju_status()
+
+    units = []
+    for service in status['services']:
+        if 'units' in status['services'][service]:
+            for u in status['services'][service]['units']:
+                unit = ServiceUnit(u, status['services'][service]['units'][u])
+                units.append(unit)
+                if subordinates and unit.subordinates:
+                    for s in unit.subordinates:
+                        units.append(ServiceUnit(s, unit.subordinates[s],
+                                                 subordinate=True))
+    return units
+
+
+def print_unit(unit, indent=0, quiet=False):
+    status_line = "%s: %s %s (%s)"
+    if not quiet:
+        status_line = "%s- " + status_line
+    else:
+        indent = 0
+        status_line = "%s" + status_line
+
+    print status_line % (" " * indent, unit.name,
+                         unit['public-address'],
+                         ', '.join(unit['open-ports']), unit['agent-state'])


### PR DESCRIPTION
- Users must run the set_trace() call before use this plugin, then invoke this by running:
  $ juju pdb unit/0 4444
- Added utils file to group some plugin common methods.
- Modified pprint plugin to use utils file.
