### PR TITLE
Added aligned mode to pprint for easier at-a-glance reading

### DIFF
--- a/juju-pprint
+++ b/juju-pprint
@@ -17,28 +17,33 @@
 
 import sys
 
-from utils import get_units, print_unit
+from utils import get_units, print_unit, get_max_lens
 
 
 def main():
-    quiet = False
     # I heard they invented this cool thing called argparse
     if '--description' in sys.argv:
         print "Collapsed, pretty version of juju status"
         sys.exit()
 
     if '--help' in sys.argv:
+        print "Usage: juju pprint [options]"
         print "Collapsed, pretty version of juju stats"
+        print ""
+        print "Options:"
+        print "  -q  Use quiet (super-condensed) mode"
+        print "  -a  Use aligned mode"
         sys.exit()
 
-    if '-q' in sys.argv:
-        quiet = True
+    quiet = '-q' in sys.argv
 
-    for unit in get_units():
-        if not unit.subordinate:
-            print_unit(unit, quiet=quiet)
-        else:
-            print_unit(unit, 2, quiet=quiet)
+    align = not quiet and '-a' in sys.argv
+
+    units = get_units()
+    name_width, addr_width, stat_width = get_max_lens(units, align)
+    for unit in units:
+        indent = 2 if unit.subordinate else 0
+        print_unit(unit, indent, quiet, name_width, addr_width, stat_width)
 
 
 if __name__ == "__main__":

--- a/utils.py
+++ b/utils.py
@@ -45,14 +45,29 @@ def get_units(subordinates=True):
     return units
 
 
-def print_unit(unit, indent=0, quiet=False):
-    status_line = "%s: %s %s (%s)"
+def get_max_lens(units, align):
+    if not align:
+        return (0, 0, 0)
+    max_name_len = 0
+    max_addr_len = 0
+    max_stat_len = 0
+    for unit in units:
+        max_name_len = max(len(unit.name), max_name_len)
+        max_addr_len = max(len(unit.public_address), max_addr_len)
+        max_stat_len = max(len(unit.agent_state), max_stat_len)
+    return max_name_len, max_addr_len, max_stat_len
+
+
+def print_unit(unit, indent=0, quiet=False, name_width=0, addr_width=0, stat_width=0):
+    status_line = "%-*s %-*s (%*s) %s"
     if not quiet:
         status_line = "%s- " + status_line
     else:
         indent = 0
         status_line = "%s" + status_line
 
-    print status_line % (" " * indent, unit.name,
-                         unit['public-address'],
-                         ', '.join(unit['open-ports']), unit['agent-state'])
+    print status_line % (" " * indent,
+                         name_width + 3 - indent, unit.name + ':',
+                         addr_width, unit.public_address,
+                         stat_width, unit.agent_state,
+                         ', '.join(unit.open_ports))


### PR DESCRIPTION
Sample output:

```
- mongodb/0:             10.0.3.220 (   pending) 27017/tcp, 27019/tcp, 27021/tcp, 28017/tcp
  - mongodb-sentry/0:    10.0.3.220 (installing) 9001/tcp
- ceilometer/0:          10.0.3.11  (   started) 8777/tcp
  - ceilometer-sentry/0: 10.0.3.11  (      down) 9001/tcp
- relation-sentry/0:     10.0.3.159 (      down) 9001/tcp
```
