### PR TITLE
Switch python3 -> python

### DIFF
--- a/juju-kill
+++ b/juju-kill
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 # vim: ts=4 sw=4 et
 # Copyright Canonical Ltd 2014, released under AGPL
 import yaml


### PR DESCRIPTION
The plugin doesn’t work out of the box with a Vagrant image, because
python3-yaml is not installed. There don’t seem to be any
python3-specific functionality, so I’ve downgraded to match other
plugins.
