### PR TITLE
Sync charm

### DIFF
--- a/juju-sync-charm
+++ b/juju-sync-charm
@@ -13,6 +13,12 @@ if [ "$1" == "--help" ]; then
 fi
 
 
+if [ "$1" == "-y" ]; then
+    FORCE=yes
+    shift
+fi
+
+
 if [ -z "$1" ]
 then
     echo "You must provide a unit name" >&2
@@ -22,11 +28,13 @@ fi
 UNIT=$1
 DIR=${2:-.}
 
-echo "WARNING: This will attempt to merge local changes to the charm on $UNIT into $DIR"
-read -p "Continue? [y/N] " doit
-if [ "${doit,,}" != "y" ]
-then
-    exit 1
+if [ -z "$FORCE" ]; then
+    echo "WARNING: This will attempt to merge local changes to the charm on $UNIT into $DIR"
+    read -p "Continue? [y/N] " doit
+    if [ "${doit,,}" != "y" ]
+    then
+        exit 1
+    fi
 fi
 
 IP=$(juju stat $UNIT | grep -F public-address | head -1 | awk '{ print $2 }')


### PR DESCRIPTION
The sync-charm plugin didn't work for me out of the box, because it wasn't using Juju's ssh identity file.  This change points it to the Juju identity file and disables the host key checking, to better match normal Juju command behavior.

It also adds an option to skip the "are you sure you want to do this" prompt, because, why wouldn't I?
