### PR TITLE
Adds functionality to cleanup juju daemons and lxc cruft

### DIFF
--- a/juju-clean
+++ b/juju-clean
@@ -39,12 +39,33 @@ fi
 echo "Destroying '$JUJU_ENV' environment" >&2
 juju destroy-environment -y $JUJU_ENV >/dev/null 2>&1 || true
 juju destroy-environment --force -y $JUJU_ENV >/dev/null 2>&1 || true
+
 echo "Removing any extra files" >&2
+echo "WARNING: This plugin does not handle encrypted home directories yet." >&2
 rm -f ~/.juju/environments/$JUJU_ENV.jenv
 rm -rf ~/.juju/$JUJU_ENV || true
+
 echo "Checking for errors with local provider" >&2
+
+echo "Stopping juju daemons" >&2
+for jujudaemon in $(sudo initctl list | grep juju | cut -d ' ' -f 1)
+do
+    sudo stop ${jujudaemon}
+done
+echo "Destroying juju template containers" >&2
+for container in $(sudo lxc-ls | grep -e "^juju.*template$" )
+do
+  sudo lxc-stop --name ${container} && sudo lxc-destroy --name ${container} || true
+done
+
+echo "Cleaning local providor files" >&2
+sudo rm /etc/init/juju-* || true
+sudo rm /etc/rsyslog.d/25-juju* || true
+sudo rm -rf /var/lib/juju/containers/${USER}-* || true
 sudo rm -rf /var/lib/juju/locks/* || true
-sudo lxc-stop -n juju-precise-template && sudo lxc-destroy -n juju-precise-template || true
-sudo lxc-stop -n juju-trusty-template && sudo lxc-destroy -n juju-trusty-template || true
+echo "Cleaning lxc files" >&2
 sudo rm -rf /var/cache/lxc/cloud-* || true
+sudo rm /var/lib/lxc/juju-* || true
+sudo rm /etc/lxc/auto/${USER}-* || true
+
 echo "Clean and ready for bootstrap"

--- a/juju-clean
+++ b/juju-clean
@@ -18,6 +18,7 @@
 set -e
 
 JUJU_ENV=$1
+JUJU_HOME=${JUJU_HOME:-~/.juju}
 
 if [ ! "$JUJU_ENV" ]; then
   echo "Please run juju clean <environment>"
@@ -40,17 +41,16 @@ echo "Destroying '$JUJU_ENV' environment" >&2
 juju destroy-environment -y $JUJU_ENV >/dev/null 2>&1 || true
 juju destroy-environment --force -y $JUJU_ENV >/dev/null 2>&1 || true
 
-echo "Removing any extra files" >&2
-echo "WARNING: This plugin does not handle encrypted home directories yet." >&2
-rm -f ~/.juju/environments/$JUJU_ENV.jenv
-rm -rf ~/.juju/$JUJU_ENV || true
+echo "Removing any extra environment files in '${JUJU_HOME}'" >&2
+rm -f ~/${JUJU_HOME}/environments/$JUJU_ENV.jenv
+rm -rf ~/${JUJU_HOME}/$JUJU_ENV || true
 
 echo "Checking for errors with local provider" >&2
 
 echo "Stopping juju daemons" >&2
 for jujudaemon in $(sudo initctl list | grep juju | cut -d ' ' -f 1)
 do
-    sudo stop ${jujudaemon}
+    sudo stop ${jujudaemon} || true
 done
 echo "Destroying juju template containers" >&2
 for container in $(sudo lxc-ls | grep -e "^juju.*template$" )


### PR DESCRIPTION
Please do not merge this. I have questions and it is not fully tested.

I'm making a pull request based on a conversation in irc about cleanup. When my local environment is in a bad state I've been running http://paste.ubuntu.com/9677575/ (cobbled from a discussion in irc and [this answer](http://askubuntu.com/questions/403618/how-do-i-clean-up-a-machine-after-using-the-local-provider/403619#403619)). In irc we were discussing clean and it prompted a PR nudge.

Questions/Comments about this PR
* This destroys any containers named ^juju.*template$ but I may have the naming convention wrong. I just guessed.
* Maybe the lxc logic should be considered a separate concern and handled outside of this plugin, but to be honest I'd just keep using my script that destroys everything. Maybe that would be true for the majority of users.
* Is this deleting more files than it should?
* This plugin allows a user to specify a non-local environment. Should I check that the environment is local before raining destruction down on the local containers, caches, daemons, etc.?
* I think you'll want to have a verbose option but maybe YAGNI
* How forgiving should this be? should I let things fail if this fails to stop a service or destroy a container?



