### PR TITLE
Add crashdump juju plugin

### DIFF
--- a/juju-crashdump
+++ b/juju-crashdump
@@ -83,7 +83,10 @@ def set_model(model):
 
 
 def run_cmd(command):
-    subprocess.check_call(command, shell=True)
+    try:
+        subprocess.check_call(command, shell=True)
+    except:
+        print('Command "%s" failed' % command)
 
 
 def juju_cmd(command):
@@ -119,7 +122,7 @@ class CrashCollector(object):
         )
         tar_cmd = TAR_CMD.format(dirs=" ".join(directories),
                                  max_size=self.max_size, uuid=self.uuid)
-        juju_cmd("""run --all 'sh -c "%s"'""" % tar_cmd)
+        run_cmd("""timeout 30s juju run --all 'sh -c "%s"'""" % tar_cmd)
 
     def retrieve_unit_tarballs(self):
         juju_status = yaml.load(open('juju_status.yaml', 'r'))

--- a/juju-crashdump
+++ b/juju-crashdump
@@ -183,7 +183,7 @@ class ShowDescription(argparse.Action):
 
 def parse_args():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-d', '--description', action=ShowDescription,
+    parser.add_argument('-d', '--description', nargs=0, action=ShowDescription,
                         help='Output a short description of the plugin')
     parser.add_argument('-m', '--model', default=None,
                         help='Model to act on')

--- a/juju-crashdump
+++ b/juju-crashdump
@@ -1,0 +1,209 @@
+#!/usr/bin/env python2
+# this is python2/3 compatible, but the following bug breaks us... 
+# https://bugs.launchpad.net/ubuntu/+source/python-launchpadlib/+bug/1425575
+
+# you also might need to $ sudo apt install python-apport
+
+import os
+import sys
+import argparse
+import tempfile
+import subprocess
+import shlex
+import shutil
+import uuid
+import yaml
+from collections import defaultdict
+from os.path import expanduser
+import apport
+import apport.crashdb
+import apport.hookutils
+from textwrap import dedent
+
+
+MAX_FILE_SIZE = 5000000 # 5MB max for files
+DIRECTORIES = [
+    '/var/lib/juju',
+    '/var/log',
+    '/etc/ceph',
+    '/etc/cinder',
+    '/etc/glance',
+    '/etc/keystone',
+    '/etc/neutron',
+    '/etc/nova',
+    '/etc/quantum',
+    '/etc/swift',
+    '/opt/nedge/var/log',
+    '/usr/share/lxc/config',
+    '/var/lib/libvirt/filesystems/plumgrid-data/log',
+    '/var/lib/libvirt/filesystems/plumgrid/var/log',
+]
+
+TAR_CMD = """sudo find {dirs} -mount -type f -size -{max_size}c -o \
+-size {max_size}c 2>/dev/null | sudo tar -pcf /tmp/juju-dump-{uuid}.tar \
+--files-from - 2>/dev/null"""
+
+
+def service_unit_addresses(status):
+    """From a given juju_status.yaml dict return a mapping of
+    {'<ip>': ['<service1>', '<service2>', '<machine/container>']}."""
+    out = defaultdict(set)
+    units = set()
+    for m_id, m_info in status['machines'].items():
+        if 'dns-name' not in m_info:
+            continue
+        out[m_info['dns-name']].add("machine_%s" % m_id)
+        for c_id, c_info in m_info.get('containers', {}).items():
+            if 'dns-name' not in c_info:
+                continue
+            out[c_info['dns-name']].add("container_%s" % c_id)
+
+    for _, a_info in status['applications'].items():
+        if 'subordinate-to' in a_info:
+            continue
+        for u_id, u_info in a_info.get('units', {}).items():
+            if 'public-address' not in u_info:
+                continue
+            addr = u_info['public-address']
+            out[addr].add(u_id)
+            units.add(u_id)
+            if 'subordinates' in u_info:
+                for s_id, s_info in u_info['subordinates'].items():
+                    if 'public-address' not in s_info:
+                        continue
+                    addr = s_info['public-address']
+                    out[addr].add(s_id)
+
+    return out, units
+
+
+def set_model(model):
+    os.environ['JUJU_ENV'] = model
+    os.environ['JUJU_MODEL'] = model
+
+
+def run_cmd(command):
+    subprocess.check_call(command, shell=True)
+
+
+def juju_cmd(command):
+    command_prefix = 'juju '
+    run_cmd(command_prefix + command)
+
+
+def juju_status():
+    juju_cmd('status --format=yaml > juju_status.yaml')
+
+
+def juju_debuglog():
+    juju_cmd('debug-log --replay --no-tail > debug_log.txt')
+
+
+class CrashCollector(object):
+    """A log file collector for juju and charms"""
+    def __init__(self, model, max_size, extra_dirs):
+        if model:
+            set_model(model)
+        self.max_size = max_size
+        self.extra_dirs = extra_dirs
+        self.cwd = os.getcwd()
+        self.tempdir = tempfile.mkdtemp(dir=expanduser('~'))
+        os.chdir(self.tempdir)
+        self.uuid = uuid.uuid4()
+
+    def create_unit_tarballs(self):
+        directories = list(DIRECTORIES)
+        directories.extend(self.extra_dirs)
+        directories.extend(
+            ['/var/lib/lxd/containers/*/rootfs' + item for item in directories]
+        )
+        tar_cmd = TAR_CMD.format(dirs=" ".join(directories),
+                                 max_size=self.max_size, uuid=self.uuid)
+        juju_cmd("""run --all 'sh -c "%s"'""" % tar_cmd)
+
+    def retrieve_unit_tarballs(self):
+        juju_status = yaml.load(open('juju_status.yaml', 'r'))
+        aliases, units = service_unit_addresses(juju_status) 
+        for ip, alias_group in aliases.items():
+            any_unit = alias_group.intersection(units).pop()
+            juju_cmd("scp %s:/tmp/juju-dump-%s.tar ." % (any_unit, self.uuid))
+            shutil.move("juju-dump-%s.tar" % self.uuid, "%s.tar" % ip)
+            for alias in alias_group:
+                os.symlink('%s.tar' % ip, '%s.tar' % alias.replace('/', '_'))
+
+    def collect(self):
+        juju_status()
+        juju_debuglog()
+        self.create_unit_tarballs()
+        self.retrieve_unit_tarballs()
+        tar_file = "juju-crashdump-%s.tar" % self.uuid
+        run_cmd("tar -pcf %s * 2>/dev/null" % tar_file)
+        run_cmd("gzip --force %s" % tar_file)
+        os.chdir(self.cwd)
+        gzipped_file = tar_file + '.gz'
+        shutil.move(os.path.join(self.tempdir, gzipped_file), '.')
+        self.cleanup()
+        return gzipped_file
+
+    def cleanup(self):
+        shutil.rmtree(self.tempdir)
+
+
+def upload_file_to_bug(bugnum, file_):
+    crashdb = crashdb = apport.crashdb.get_crashdb(None)
+    if not crashdb.can_update(bugnum):
+        print(dedent("""
+            You are not the reporter or subscriber of this problem report,
+            or the report is a duplicate or already closed.
+            
+            Please create a new report on https://bugs.launchpad.net/charms.
+            """))
+        return False
+
+    is_reporter = crashdb.is_reporter(bugnum)
+
+    report = apport.Report('Bug')
+    apport.hookutils.attach_file(report, file_, overwrite=False)
+    if len(report) != 0:
+        print("Starting upload to lp:%s" % bugnum)
+        crashdb.update(bugnum, report,
+        'apport information', change_description=is_reporter,
+        attachment_comment='juju crashdump')
+
+
+class ShowDescription(argparse.Action):
+    """Helper for implementing --description using argparse"""
+    def __init__(self, *args, **kwargs):
+        super(ShowDescription, self).__init__(*args, **kwargs)
+
+    def __call__(self, parser, *args, **kwargs):
+        print(CrashCollector.__doc__)
+        sys.exit(0)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument('-d', '--description', action=ShowDescription,
+                        help='Output a short description of the plugin')
+    parser.add_argument('-m', '--model', default=None,
+                        help='Model to act on')
+    parser.add_argument('-f', '--max-file-size',  default=MAX_FILE_SIZE,
+                        help='The max file size (bytes) for included files')
+    parser.add_argument('-b', '--bug', default=None,
+                        help='Upload crashdump to the given launchpad bug #')
+    parser.add_argument('extra_dir', nargs='*', default=[],
+                        help='Extra directories to snapshot')
+    return parser.parse_args()
+
+
+def main():
+    opts = parse_args()
+    collector = CrashCollector(model=opts.model, max_size=opts.max_file_size,
+                               extra_dirs=opts.extra_dir)
+    filename = collector.collect()
+    if opts.bug:
+        upload_file_to_bug(opts.bug, filename)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Add a crashdump plugin.

Creates a gzipped-tarball of useful log and lib directories on every unit, the juju status & debug-log.

Can also upload this to a launchpad bug. This is python2/3 compat, except for https://bugs.launchpad.net/ubuntu/+source/python-launchpadlib/+bug/1425575 -- so we use python2 by default.