### PR TITLE
Remove unused import

### DIFF
--- a/juju-crashdump
+++ b/juju-crashdump
@@ -9,7 +9,6 @@ import sys
 import argparse
 import tempfile
 import subprocess
-import shlex
 import shutil
 import uuid
 import yaml


### PR DESCRIPTION
Reported by pyflakes:

juju-crashdump:12: 'shlex' imported but unused